### PR TITLE
Fix for 'pod install' on Mac OS X

### DIFF
--- a/ios/flutter_permissions_helper.podspec
+++ b/ios/flutter_permissions_helper.podspec
@@ -17,5 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   
   s.ios.deployment_target = '8.0'
+  s.swift_version = '4.1'
 end
 


### PR DESCRIPTION
Fix for the error:
- `flutter_permissions_helper` does not specify a Swift version and none of the target (`Runner`) integrating it have the `SWIFT_VERSION` attribute set.